### PR TITLE
Increase VM CPU and memory size.

### DIFF
--- a/ansible/roles/vm_set/templates/sonic_vm.xml.j2
+++ b/ansible/roles/vm_set/templates/sonic_vm.xml.j2
@@ -1,8 +1,8 @@
 <domain type='kvm' xmlns:qemu='http://libvirt.org/schemas/domain/qemu/1.0'>
   <name>{{ vm_name }}</name>
-  <memory unit='GiB'>4</memory>
-  <currentMemory unit='GiB'>4</currentMemory>
-  <vcpu placement='static'>2</vcpu>
+  <memory unit='GiB'>8</memory>
+  <currentMemory unit='GiB'>8</currentMemory>
+  <vcpu placement='static'>4</vcpu>
   <resource>
     <partition>/machine</partition>
   </resource>

--- a/docs/testbed/README.testbed.SmartSwitch.VsSetup.md
+++ b/docs/testbed/README.testbed.SmartSwitch.VsSetup.md
@@ -75,7 +75,7 @@
     scp sonic-mgmt/ansible/minigraph/SONIC01DPU.xml admin@10.250.0.55:
 
     User:admin
-    Password: password
+    Password: YourPaSsWoRd
     ```
 
 1. load minigraph on DPU


### PR DESCRIPTION
Without this change, the DPU image can be crazily slow after launch BMv2 data plane.